### PR TITLE
fixed duplicate toasts

### DIFF
--- a/src/components/MapStateSaver.svelte
+++ b/src/components/MapStateSaver.svelte
@@ -22,6 +22,7 @@
   let channel
   let masterMapId
   let userId
+  let deletedByCurrentUser = false
   export let map
 
   onMount(() => {
@@ -41,7 +42,7 @@
         },
         async (payload) => {
           // First check if it's current user's change
-          if (payload.new.update_user_id === userId) {
+          if ((payload.new.update_user_id === userId) || (payload.new.deleted && deletedByCurrentUser)) {
             console.log("Skipping synchronization, update made by current user")
             return
           }
@@ -364,14 +365,14 @@
       )
 
       if (serverMarker) {
-        if (
-          new Date(removedMarker.last_confirmed) >=
-          new Date(serverMarker.last_confirmed)
-        ) {
-          // If the removal last_confirmed is newer or equal to the server marker's last_confirmed,
-          // add the marker to serverMarkersToBeDeleted
+        // deleted by current user
+        if (removedMarker.deletedBy === userId) {
+          deletedByCurrentUser = true
           serverMarkersToBeDeleted.push(serverMarker)
           showLocalChangeToast("update", serverMarker.iconClass, true)
+        } else {
+          deletedByCurrentUser = false
+          localMarkersToBeDeleted.push(serverMarker)
         }
       }
     }

--- a/src/components/MarkerManager.svelte
+++ b/src/components/MarkerManager.svelte
@@ -7,6 +7,7 @@
     markerActionsStore,
     locationMarkerStore,
   } from "../stores/mapStore"
+  import { profileStore } from "../stores/profileStore"
   import { controlStore } from "../stores/controlStore"
   import { getContext, onMount, onDestroy } from "svelte"
   import mapboxgl from "mapbox-gl"
@@ -404,10 +405,13 @@
 
   function removeMarker() {
     // Remove the recent marker from the map
+
     if ($selectedMarkerStore) {
       const { marker, id } = $selectedMarkerStore
       marker.remove()
       selectedMarkerStore.set(null)
+
+      let deletedBy = $profileStore.id
 
       const existingMarker = $confirmedMarkersStore.find((m) => m.id === id)
       if (existingMarker) {
@@ -416,7 +420,7 @@
           const updatedMarkers = markers.filter((m) => m.id !== id)
           removeMarkerStore.update((removedMarkers) => [
             ...removedMarkers,
-            { id, last_confirmed: existingMarker.last_confirmed },
+            { id, deletedBy, last_confirmed: existingMarker.last_confirmed },
           ])
           return updatedMarkers
         })


### PR DESCRIPTION
- Fixed duplicate toasts.
- Added localMarkersToBeDeleted (out of scope).
The issue occurs because the code couldn't determine whether the marker was deleted by the current user or another user. As a result, both showLocalChangeToast and showChangeToast were called.

I wanted to use removedMarker.last_confirmed and serverMarker.last_confirmed. However, their date-times are always the same, which I believe is a data issue. This is the only solution I can use to fix it.